### PR TITLE
Convert API to use promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ const daemon = new Daemon('http://node.monero.hashvault.pro:18081') // or use a 
 Look up how many blocks are in the longest chain known to the node.
 
 ```js
-daemon.getLastBlockHeight((err, height) => {
-    if (err) return console.log(err)
+daemon.getLastBlockHeight().then(height => {
     console.log(height) // 993163
 })
 ```
@@ -70,8 +69,7 @@ daemon.getLastBlockHeight((err, height) => {
 Look up how many blocks are in the longest chain known to the node.
 
 ```js
-daemon.getLastBlockHeader((err, header) => {
-    if (err) return console.log(err)
+daemon.getLastBlockHeader().then(header => {
     console.log(header)
     /*
      * {
@@ -98,8 +96,7 @@ Block header information can be retrieved using either a block's hash or height.
 By height:
 
 ```js
-daemon.getBlockHeader(990793, (err, header) => {
-    if (err) return console.log(err)
+daemon.getBlockHeader(990793).then(header => {
     console.log(header)
     /*
      * {
@@ -122,8 +119,7 @@ daemon.getBlockHeader(990793, (err, header) => {
 By hash:
 
 ```js
-daemon.getBlockHeader('ac0f1e2262...', (err, header) => {
-    if (err) return console.log(err)
+daemon.getBlockHeader('ac0f1e2262...').then(header => {
     console.log(header)
     /*
      * {
@@ -148,8 +144,7 @@ daemon.getBlockHeader('ac0f1e2262...', (err, header) => {
 Full block information can be retrieved by either block height or hash, like with the block header calls.
 
 ```js
-daemon.getBlock('ac0f1e2262...', (err, block) => {
-    if (err) return console.log(err)
+daemon.getBlock('ac0f1e2262...').then(block => {
     console.log(block) // { ... }
 })
 ```
@@ -159,8 +154,7 @@ daemon.getBlock('ac0f1e2262...', (err, block) => {
 Get a new block template for mining.
 
 ```js
-daemon.getBlockTemplate('46tFLJPaNyy...', 17, (err, template) => {
-    if (err) return console.log(err)
+daemon.getBlockTemplate('46tFLJPaNyy...', 17).then(template => {
     console.log(template) // { ... }
 })
 ```
@@ -170,8 +164,7 @@ daemon.getBlockTemplate('46tFLJPaNyy...', 17, (err, template) => {
 Submit a block to the network.
 
 ```js
-daemon.getBlockTemplate('...', (err) => {
-    if (err) return console.log(err)
+daemon.submitBlock('...').then(result => {
     console.log('hurray') // 'hurray'
 })
 ```
@@ -181,8 +174,7 @@ daemon.getBlockTemplate('...', (err) => {
 Check if a key image is spent.
 
 ```js
-daemon.getKeyImagesSpent(['8d1bd818...', '7319134bf...'], (err, status) => {
-    if (err) return console.log(err)
+daemon.getKeyImagesSpent(['8d1bd818...', '7319134bf...']).then(status =>
     console.log(status) // [1, 1]
 })
 ```
@@ -190,8 +182,7 @@ daemon.getKeyImagesSpent(['8d1bd818...', '7319134bf...'], (err, status) => {
 ###### stop(callback)
 
 ```js
-daemon.stop((err) => {
-    if (err) return console.log(err)
+daemon.stop().then(() => {
     console.log(':(') // ':('
 })
 ```
@@ -200,8 +191,7 @@ daemon.stop((err) => {
 Get miscellaneous information about the state of this daemon and the network.
 
 ```js
-daemon.getInfo((err, info) => {
-    if (err) return console.log(err)
+daemon.getInfo().then(info => {
     console.log(info)
     /*
      * {
@@ -228,8 +218,7 @@ daemon.getInfo((err, info) => {
 Get miscellaneous information about the state of this daemon and the network.
 
 ```js
-daemon.isTestnet((err, testnet) => {
-    if (err) return console.log(err)
+daemon.isTestnet().then(testnet => {
     console.log(testnet) // false
 })
 ```
@@ -262,8 +251,7 @@ const wallet = new Wallet('http://localhost:18082')
 Get the wallet's address.
 
 ```js
-wallet.getAddress((err, address) => {
-    if (err) return console.log(err)
+wallet.getAddress().then(address => {
     console.log(address) // '46tFLJPaNyy...'
 })
 ```
@@ -273,8 +261,7 @@ wallet.getAddress((err, address) => {
 Get the wallet's balance.
 
 ```js
-wallet.getBalance((err, balance) => {
-    if (err) return console.log(err)
+wallet.getBalance(balance).then(balance => {
     console.log(balance.total) // 140000000000
     console.log(balance.unlocked) // 50000000000
 })
@@ -291,8 +278,7 @@ wallet.transfer({
     ],
     mixin: 5, // default 5
     priority: 0 // default 0
-}, (err, result) => {
-    if (err) return console.log(err)
+}).then(result) => {
     console.log(result.fee) // 48958481211
     console.log(result.tx_hash) // '985180f46863...'
 })
@@ -303,8 +289,7 @@ wallet.transfer({
 Get a list of incoming payments using a given payment id.
 
 ```js
-wallet.getPayments('4279257e...', (err, payments) => {
-    if (err) return console.log(err)
+wallet.getPayments('4279257e...').then(payments => {
     console.log(payments)
     /*
      * [
@@ -325,8 +310,7 @@ wallet.getPayments('4279257e...', (err, payments) => {
 Generate a random integrated address.
 
 ```js
-wallet.getRandomIntegratedAddress((err, result) => {
-    if (err) return console.log(err)
+wallet.getRandomIntegratedAddress().then(result => {
     console.log(result.paymentId) // 'f89f4978b6304b7b'
     console.log(result.address) // '46tFLJPaNyy...'
 })
@@ -337,8 +321,7 @@ wallet.getRandomIntegratedAddress((err, result) => {
 Get a list of payments using a list of payment ids from a given height.
 
 ```js
-wallet.getBulkPayments(['4279257e0a2...'], 990000, (err, result) => {
-    if (err) return console.log(err)
+wallet.getBulkPayments(['4279257e0a2...'], 990000).then(result => {
     console.log(result)
     /*
      * [

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -29,15 +29,16 @@ class Daemon {
   /**
    * Look up how many blocks are in the longest chain known to the node.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @returns {void}
+   * @returns {Promise.<number>} count
    */
-  getLastBlockHeight (cb) {
-    this.client.request('getblockcount', [], (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getLastBlockHeight () {
+    return new Promise((resolve, reject) => {
+      this.client.request('getblockcount', [], (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      return cb(null, response.result.count)
+        return resolve(response.result.count)
+      })
     })
   }
 
@@ -45,15 +46,16 @@ class Daemon {
    * Block header information for the most recent block is easily retrieved with
    * this method.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @returns {void}
+   * @returns {Promise.<Object>} block header
    */
-  getLastBlockHeader (cb) {
-    this.client.request('getlastblockheader', [], (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getLastBlockHeader () {
+    return new Promise((resolve, reject) => {
+      this.client.request('getlastblockheader', [], (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      return cb(null, response.result.block_header)
+        return resolve(response.result.block_header)
+      })
     })
   }
 
@@ -62,27 +64,28 @@ class Daemon {
    * height.
    *
    * @param {number|string} id A block height or block hash
-   * @param {Function} cb A callback to recieve the result
-   * @returns {void}
+   * @returns {Promise.<Object>} block header
    */
-  getBlockHeader (id, cb) {
-    if (typeof id === 'number') {
-      this.client.request('getblockheaderbyheight', { height: id }, (err, response) => {
-        if (err) return cb(err)
-        if (response.error) return cb(response.error.message)
+  getBlockHeader (id) {
+    return new Promise((resolve, reject) => {
+      if (typeof id === 'number') {
+        this.client.request('getblockheaderbyheight', { height: id }, (err, response) => {
+          if (err) return reject(err)
+          if (response.error) return reject(new Error(response.error.message))
 
-        return cb(null, response.result.block_header)
-      })
-    } else if (typeof id === 'string') {
-      this.client.request('getblockheaderbyhash', { hash: id }, (err, response) => {
-        if (err) return cb(err)
-        if (response.error) return cb(response.error.message)
+          return resolve(response.result.block_header)
+        })
+      } else if (typeof id === 'string') {
+        this.client.request('getblockheaderbyhash', { hash: id }, (err, response) => {
+          if (err) return reject(err)
+          if (response.error) return reject(new Error(response.error.message))
 
-        return cb(null, response.result.block_header)
-      })
-    } else {
-      return cb('id must be of type number or string')
-    }
+          return resolve(response.result.block_header)
+        })
+      } else {
+        return reject(new Error('id must be of type number or string'))
+      }
+    })
   }
 
   /**
@@ -90,25 +93,26 @@ class Daemon {
    * like with the block header calls.
    *
    * @param  {number|string} id A block height or block hash
-   * @param  {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<Object>} block
    */
-  getBlock (id, cb) {
-    if (typeof id !== 'number' && typeof id !== 'string') {
-      return cb('id must be of type number or string')
-    }
+  getBlock (id) {
+    return new Promise((resolve, reject) => {
+      if (typeof id !== 'number' && typeof id !== 'string') {
+        return reject(new Error('id must be of type number or string'))
+      }
 
-    const params = typeof id === 'number' ? { height: id } : { hash: id }
+      const params = typeof id === 'number' ? { height: id } : { hash: id }
 
-    this.client.request('getblock', params, (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+      this.client.request('getblock', params, (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      const result = response.result
-      return cb(null, {
-        blob: result.blob,
-        body: result.json,
-        header: result.block_header
+        const result = response.result
+        return resolve({
+          blob: result.blob,
+          body: result.json,
+          header: result.block_header
+        })
       })
     })
   }
@@ -118,26 +122,27 @@ class Daemon {
    *
    * @param {string} address Address of wallet to receive coinbase transaction
    * @param {number} reserved Reserve size
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<Object>} block template
    */
-  getBlockTemplate (address, reserved, cb) {
-    const params = {
-      wallet_address: address,
-      reserve_size: reserved
-    }
+  getBlockTemplate (address, reserved) {
+    return new Promise((resolve, reject) => {
+      const params = {
+        wallet_address: address,
+        reserve_size: reserved
+      }
 
-    this.client.request('getblocktemplate', params, (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+      this.client.request('getblocktemplate', params, (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      const result = response.result
-      return cb(null, {
-        blob: result.blocktemplate_blob,
-        difficulty: result.difficulty,
-        height: result.height,
-        previous: result.prev_hash,
-        offset: result.reserved_offset
+        const result = response.result
+        return resolve({
+          blob: result.blocktemplate_blob,
+          difficulty: result.difficulty,
+          height: result.height,
+          previous: result.prev_hash,
+          offset: result.reserved_offset
+        })
       })
     })
   }
@@ -146,15 +151,15 @@ class Daemon {
    * Submit a block to the network.
    *
    * @param {string} blob Block blob data
-   * @param {Function} cb A callback after the block has been submitted
-   * @return {void}
+   * @return {Promise.<Object>} result
    */
-  submitBlock (blob, cb) {
-    this.client.request('submitblock', { blob }, (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
-
-      return cb(null)
+  submitBlock (blob) {
+    return new Promise((resolve, reject) => {
+      this.client.request('submitblock', { blob }, (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
+        return resolve(response.result)
+      })
     })
   }
 
@@ -163,30 +168,32 @@ class Daemon {
    * output.
    *
    * @param {Array.string} keys An array of key images to check
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise} result
    */
-  getKeyImagesSpent (keys, cb) {
-    request({
-      url: `${this.host}/is_key_image_spent`,
-      method: 'POST',
-      json: { key_images: keys }
-    }, (err, response, body) => {
-      if (err) return cb(err)
-      cb(null, body.spent_status)
+  getKeyImagesSpent (keys) {
+    return new Promise((resolve, reject) => {
+      request({
+        url: `${this.host}/is_key_image_spent`,
+        method: 'POST',
+        json: { key_images: keys }
+      }, (err, response, body) => {
+        if (err) return reject(err)
+        resolve(body.spent_status)
+      })
     })
   }
 
   /**
    * Safely stop the daemon.
    *
-   * @param {Function} cb A callback after the shutdown command has been sent
-   * @return {void}
+   * @return {Promise} null
    */
-  stop (cb) {
-    request.post(`${this.host}/stop`, (err, response, body) => {
-      if (err) return cb(err)
-      cb(null)
+  stop () {
+    return new Promise((resolve, reject) => {
+      request.post(`${this.host}/stop`, (err, response, body) => {
+        if (err) return reject(err)
+        resolve(null)
+      })
     })
   }
 
@@ -194,29 +201,27 @@ class Daemon {
    * Get miscellaneous information about the state of this daemon and the
    * network.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<Object>} result
    */
-  getInfo (cb) {
-    this.client.request('get_info', [], (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getInfo () {
+    return new Promise((resolve, reject) => {
+      this.client.request('get_info', [], (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      return cb(null, response.result)
+        return resolve(response.result)
+      })
     })
   }
 
   /**
    * Checks if this daemon is running on the testnet, or the mainnet.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<Boolean>} result
    */
-  isTestnet (cb) {
-    this.getInfo((err, result) => {
-      if (err) return cb(err)
-      return cb(null, result.testnet)
-    })
+  isTestnet () {
+    return this.getInfo()
+      .then(({ testnet }) => testnet)
   }
 }
 

--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -11,114 +11,72 @@ const Daemon = require('./daemon')
 
 const daemon = new Daemon('http://node.monero.hashvault.pro:18081')
 
-test('getLastBlockHeight returns a number', done => {
-  daemon.getLastBlockHeight((err, height) => {
-    if (err) done(err)
-    expect(height).toBeGreaterThan(0)
-    done()
-  })
+test('getLastBlockHeight returns a number', () => {
+  return expect(daemon.getLastBlockHeight()).resolves.toBeGreaterThan(0)
 })
 
-test('getLastBlockHeader returns something', done => {
-  daemon.getLastBlockHeader((err, header) => {
-    if (err) done(err)
-    expect(header).toBeDefined()
-    done()
-  })
+test('getLastBlockHeader returns something', () => {
+  return expect(daemon.getLastBlockHeader()).resolves.toBeDefined()
 })
 
-test('getBlockHeader returns something when passed a height', done => {
-  daemon.getBlockHeader(1491204, (err, header) => {
-    if (err) done(err)
-    expect(header).toBeDefined()
-    done()
-  })
+test('getBlockHeader returns something when passed a height', () => {
+  return expect(daemon.getBlockHeader(1491204)).resolves.toBeDefined()
 })
 
-test('getBlockHeader returns something when passed a hash', done => {
-  daemon.getBlockHeader('01928cbece02865ec587a7bce8401bd63bb79c8696b012580928282bd91f8b1b', (err, header) => {
-    if (err) done(err)
-    expect(header).toBeDefined()
-    done()
-  })
+test('getBlockHeader returns something when passed a hash', () => {
+  return expect(daemon.getBlockHeader('01928cbece02865ec587a7bce8401bd63bb79c8696b012580928282bd91f8b1b')).resolves.toBeDefined()
 })
 
-test('getBlockHeader throws an exception when an invalid parameter is passed', done => {
-  daemon.getBlock({ wow: 5 }, (err, block) => {
-    expect(err).toContain('number or string')
-    done()
-  })
+test('getBlockHeader throws an exception when an invalid parameter is passed', () => {
+  return expect(daemon.getBlockHeader({ wow: 5 })).rejects.toBeInstanceOf(Error)
 })
 
-test('getBlock returns something when passed a valid height', done => {
-  daemon.getBlock(1491204, (err, header) => {
-    if (err) done(err)
-    expect(header).toBeDefined()
-    done()
-  })
+test('getBlock returns something when passed a valid height', () => {
+  return expect(daemon.getBlock(1491204)).resolves.toBeDefined()
 })
 
-test('getBlock fails when passed an invalid height (too big)', done => {
-  daemon.getBlock(91491204, (err, block) => {
-    expect(err).toContain('height')
-    done()
-  })
+test('getBlock fails when passed an invalid height (too big)', () => {
+  return expect(daemon.getBlock(91491204)).rejects.toBeInstanceOf(Error)
 })
 
-test('getBlock fails when passed an invalid height (too small)', done => {
-  daemon.getBlock(-1, (err, block) => {
-    expect(err).toContain('Invalid params')
-    done()
-  })
+test('getBlock fails when passed an invalid height (too small)', () => {
+  return expect(daemon.getBlock(-1)).rejects.toBeInstanceOf(Error)
 })
 
-test('getBlock returns something when passed a valid hash', done => {
-  daemon.getBlock('01928cbece02865ec587a7bce8401bd63bb79c8696b012580928282bd91f8b1b', (err, block) => {
-    if (err) done(err)
-    expect(block).toBeDefined()
-    done()
-  })
+test('getBlock returns something when passed a valid hash', () => {
+  return expect(daemon.getBlock('01928cbece02865ec587a7bce8401bd63bb79c8696b012580928282bd91f8b1b')).resolves.toBeDefined()
 })
 
-test('getBlock throws an exception when an invalid parameter is passed', done => {
-  daemon.getBlock({ wow: 5 }, (err, block) => {
-    expect(err).toContain('number or string')
-    done()
-  })
+test('getBlock throws an exception when an invalid parameter is passed', () => {
+  return expect(daemon.getBlock({ wow: 5 })).rejects.toBeInstanceOf(Error)
 })
 
 test('getKeyImagesSpent returns an array of one', done => {
-  daemon.getKeyImagesSpent(['923ff0ae2b7a3407a1acc1fb67790fd9276e4e7b7ee968c8d56d14e1abee7c47'], (err, result) => {
-    if (err) return done(err)
-    expect(result).toBeInstanceOf(Array)
-    expect(result).toHaveLength(1)
-    done()
-  })
+  daemon.getKeyImagesSpent(['923ff0ae2b7a3407a1acc1fb67790fd9276e4e7b7ee968c8d56d14e1abee7c47'])
+    .then(result => {
+      expect(result).toBeInstanceOf(Array)
+      expect(result).toHaveLength(1)
+      done()
+    })
+    .catch(err => done(err))
 })
 
 test('getKeyImagesSpent returns an array of many', done => {
   daemon.getKeyImagesSpent(['923ff0ae2b7a3407a1acc1fb67790fd9276e4e7b7ee968c8d56d14e1abee7c47',
     'e941fe8fadc934035b9ebc49d242c55488b17f0aa0ea67f68ba0e14f60c05320',
-    '3a29a2c6c67aeecf8f74a2928f1a3ba6c97c94267dd7d6d1ce753143c42be43b'], (err, result) => {
-    if (err) return done(err)
-    expect(result).toBeInstanceOf(Array)
-    expect(result).toHaveLength(3)
-    done()
-  })
+    '3a29a2c6c67aeecf8f74a2928f1a3ba6c97c94267dd7d6d1ce753143c42be43b'])
+    .then(result => {
+      expect(result).toBeInstanceOf(Array)
+      expect(result).toHaveLength(3)
+      done()
+    })
+    .catch(err => done(err))
 })
 
-test('getInfo returns something', done => {
-  daemon.getInfo((err, info) => {
-    if (err) return done(err)
-    expect(info).toBeDefined()
-    done()
-  })
+test('getInfo returns something', () => {
+  return expect(daemon.getInfo()).resolves.toBeDefined()
 })
 
-test('isTestnet returns a boolean', done => {
-  daemon.isTestnet((err, testnet) => {
-    if (err) return done(err)
-    expect(testnet).toBeDefined()
-    done()
-  })
+test('isTestnet returns a boolean', () => {
+  return expect(daemon.isTestnet()).resolves.toBeDefined()
 })

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -29,34 +29,36 @@ class Wallet {
   /**
    * Get the wallet's address.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<string>} address
    */
-  getAddress (cb) {
-    this.client.request('getaddress', [], (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getAddress () {
+    return new Promise((resolve, reject) => {
+      this.client.request('getaddress', [], (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      return cb(null, response.result.address)
+        return resolve(response.result.address)
+      })
     })
   }
 
   /**
    * Get the wallet's balance.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<Object>} balance
    */
-  getBalance (cb) {
-    this.client.request('getbalance', [], (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getBalance () {
+    return new Promise((resolve, reject) => {
+      this.client.request('getbalance', [], (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      const result = response.result
+        const result = response.result
 
-      return cb(null, {
-        total: result.balance,
-        spendable: result.unlocked_balance
+        return resolve({
+          total: result.balance,
+          spendable: result.unlocked_balance
+        })
       })
     })
   }
@@ -65,26 +67,26 @@ class Wallet {
    * Send monero.
    *
    * @param {Object} options Options
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<string>} result of operation
    */
-  transfer (options, cb) {
+  transfer (options) {
     // TODO(aardvark): https://github.com/monero-project/monero/blob/5f09d6c8333b0b0d07252dc157b9e794f6278662/src/wallet/wallet2.cpp#L4959
+    return new Promise((resolve, reject) => {
+      if (!Array.isArray(options.destinations) || options.destinations.length === 0) {
+        return reject(new Error('destinations are required'))
+      }
 
-    if (!Array.isArray(options.destinations) || options.destinations.length === 0) {
-      return cb('destinations are required')
-    }
+      const defaults = {
+        mixin: 5,
+        priority: 0
+      }
 
-    const defaults = {
-      mixin: 5,
-      priority: 0
-    }
+      this.client.request('transfer', { ...defaults, ...options }, (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-    this.client.request('transfer', { ...defaults, ...options }, (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
-
-      return cb(null, response.result)
+        return resolve(response.result)
+      })
     })
   }
 
@@ -92,15 +94,16 @@ class Wallet {
    * Get a list of incoming payments using a given payment id.
    *
    * @param {string} paymentId The Payment ID
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise} incoming payments
    */
-  getPayments (paymentId, cb) {
-    this.client.request('get_payments', { payment_id: paymentId }, (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getPayments (paymentId) {
+    return new Promise((resolve, reject) => {
+      this.client.request('get_payments', { payment_id: paymentId }, (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      return cb(null, response.result.payments)
+        return resolve(response.result.payments)
+      })
     })
   }
 
@@ -108,31 +111,34 @@ class Wallet {
    * Generate a random payment id.
    *
    * @param {Boolean} integrated If the payment id is for an integrated address
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.string} payment id
    */
-  getRandomPaymentId (integrated, cb) {
-    crypto.randomBytes(integrated ? 8 : 32, (err, buf) => {
-      if (err) return cb(err)
-      return cb(null, buf.toString('hex'))
+  getRandomPaymentId (integrated) {
+    return new Promise((resolve, reject) => {
+      crypto.randomBytes(integrated ? 32 : 8, (err, buf) => {
+        if (err) return reject(err)
+        return resolve(buf.toString('hex'))
+      })
     })
   }
 
   /**
    * Generate a random integrated address.
    *
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise.<Object>} integrated address
    */
-  getRandomIntegratedAddress (cb) {
-    this.getRandomPaymentId(true, (err, paymentId) => {
-      if (err) return cb(err)
-      this.client.request('make_integrated_address', { payment_id: paymentId }, (err, response) => {
-        if (err) return cb(err)
-        if (response.error) return cb(response.error.message)
+  getRandomIntegratedAddress () {
+    return new Promise((resolve, reject) => {
+      this.getRandomPaymentId(true)
+        .then(paymentId => {
+          this.client.request('make_integrated_address', { payment_id: paymentId }, (err, response) => {
+            if (err) return reject(err)
+            if (response.error) return reject(new Error(response.error.message))
 
-        return cb(null, { paymentId, address: response.result.integrated_address })
-      })
+            return resolve({ paymentId, address: response.result.integrated_address })
+          })
+        })
+        .catch(err => reject(err))
     })
   }
 
@@ -141,15 +147,16 @@ class Wallet {
    *
    * @param {Array.string} paymentIds A list of payment ids to check
    * @param {Number} blockHeight The block height to look from
-   * @param {Function} cb A callback to recieve the result
-   * @return {void}
+   * @return {Promise} list of payments
    */
-  getBulkPayments (paymentIds, blockHeight, cb) {
-    this.client.request('get_bulk_payments', { payment_ids: paymentIds, min_block_height: blockHeight }, (err, response) => {
-      if (err) return cb(err)
-      if (response.error) return cb(response.error.message)
+  getBulkPayments (paymentIds, blockHeight) {
+    return new Promise((resolve, reject) => {
+      this.client.request('get_bulk_payments', { payment_ids: paymentIds, min_block_height: blockHeight }, (err, response) => {
+        if (err) return reject(err)
+        if (response.error) return reject(new Error(response.error.message))
 
-      cb(null, response.result.payments)
+        resolve(response.result.payments)
+      })
     })
   }
 }

--- a/lib/wallet.test.js
+++ b/lib/wallet.test.js
@@ -12,65 +12,50 @@ const Wallet = require('./wallet')
 const wallet = new Wallet('http://localhost:18082')
 
 test('getAddress returns an address', done => {
-  wallet.getAddress((err, address) => {
-    if (err) done(err)
-    expect(address).toHaveLength(95)
-    done()
-  })
+  expect(wallet.getAddress()).resolves.toHaveLength(95)
 })
 
 test('getBalance returns total and spendable balance', done => {
-  wallet.getBalance((err, balance) => {
-    if (err) done(err)
-    expect(balance.total).toBeDefined()
-    expect(balance.spendable).toBeDefined()
-    done()
-  })
+  wallet.getBalance()
+    .then(balance => {
+      expect(balance.total).toBeDefined()
+      expect(balance.spendable).toBeDefined()
+      done()
+    })
+    .catch(err => done(err))
 })
 
 test('transfer rejects bad destinations', done => {
-  wallet.transfer({ destinations: '42EuBWbYfYVcs3Hjdp4mMN6PXLUjZouNRDP6ASs52N18NcLa7aiogYE8qpyBYyuUBGGP6dWoJwwk4gQhG76UPPwfAXdcZ5K' }, (err, result) => {
-    expect(err).toMatch(/destinations/)
-    done()
-  })
+  expect(wallet.transfer({ destinations: '42EuBWbYfYVcs3Hjdp4mMN6PXLUjZouNRDP6ASs52N18NcLa7aiogYE8qpyBYyuUBGGP6dWoJwwk4gQhG76UPPwfAXdcZ5K' }))
+    .rejects
+    .toBeInstanceOf(Error)
 })
 
 test('transfer rejects bad destinations', done => {
-  wallet.transfer({ destinations: [] }, (err, result) => {
-    expect(err).toMatch(/destinations/)
-    done()
-  })
+  expect(wallet.transfer({ destinations: [] }))
+    .rejects
+    .toBeInstanceOf(Error)
 })
 
 test('getRandomPaymentId generates new style ids', done => {
-  wallet.getRandomPaymentId(true, (err, id) => {
-    if (err) return done(err)
-    expect(id).toHaveLength(16)
-    done()
-  })
+  expect(wallet.getRandomPaymentId(false)).resolves.toHaveLength(16)
 })
 
 test('getRandomPaymentId generates old style ids', done => {
-  wallet.getRandomPaymentId(false, (err, id) => {
-    if (err) return done(err)
-    expect(id).toHaveLength(64)
-    done()
-  })
+  expect(wallet.getRandomPaymentId(true)).resolves.toHaveLength(64)
 })
 
 test('getRandomIntegratedAddress', done => {
-  wallet.getRandomIntegratedAddress((err, result) => {
-    if (err) return done(err)
-    expect(result.paymentId).toBeDefined()
-    expect(result.address).toHaveLength(106)
-    done()
-  })
+  wallet.getRandomIntegratedAddress()
+    .then(result => {
+      expect(result.paymentId).toBeDefined()
+      expect(result.address).toHaveLength(106)
+      done()
+    })
+    .catch(err => done(err))
 })
 
 test('getBulkPayments returns an array', done => {
-  wallet.getBulkPayments('4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030', 990000, (err, payments) => {
-    if (err) return done(err)
-    expect(payments).toBeInstanceOf(Array)
-    done()
-  })
+  expect(wallet.getBulkPayments('4279257e0a20608e25dba8744949c9e1caff4fcdafc7d5362ecf14225f3d9030', 990000)).resolves
+    .toBeInstanceOf(Array)
 })


### PR DESCRIPTION
This uses promises instead of callbacks.
Submitting a block now returns the result.
This will probably require a major version change if accepted.
Promises reject with `Error` instance instead of string messages.

Documentation and tests were updated.